### PR TITLE
Allow developer to specify the email recipient address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 SENDGRID_USERNAME=sendgrid-username
 SENDGRID_PASSWORD=sendgrid-password
-FROM=from@from-address.com
+TO=to@to-address.com

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 SENDGRID_USERNAME=sendgrid-username
 SENDGRID_PASSWORD=sendgrid-password
+FROM=from@from-address.com 
 TO=to@to-address.com

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First, make sure you add jQuery to your page. Then do the following on form subm
 ```javascript
 $("form#id").submit(function() {
   var sendgridjs_url      = "http://yoursubdomain.herokuapp.com/send";
-  var sendgridjs_to     = $("input#to").val();
+  var sendgridjs_to       = $("input#to").val();
   var sendgridjs_subject  = $("input#subject").val();
   var sendgridjs_html     = "<p>html of email here as a string</p>";
 

--- a/README.md
+++ b/README.md
@@ -21,19 +21,45 @@ curl -X POST http://yoursubdomain.herokuapp.com/send \
 
 #### Optional: Using with JavaScript and HTML.
 
-You might have a website with a form and you want to send emails from that form to yourself. After setting up this app, you can send emails by adding the following javascript to your html page.
+You might have a website with a form and you want to send emails from that form. After setting up this app, you can send emails by adding the following javascript to your html page.
 
 First, make sure you add jQuery to your page. Then do the following on form submit.
 
 ```javascript
 $("form#id").submit(function() {
   var sendgridjs_url      = "http://yoursubdomain.herokuapp.com/send";
-  var sendgridjs_from       = $("input#from").val();
+  var sendgridjs_to     = $("input#to").val();
   var sendgridjs_subject  = $("input#subject").val();
   var sendgridjs_html     = "<p>html of email here as a string</p>";
 
   var email = {
-    from    : sendgridjs_to,
+    to      : sendgridjs_to,
+    subject : sendgridjs_subject,
+    html    : sendgridjs_html
+  }
+  $.post(sendgridjs_url, email, function(response) {
+    if (response.success) {
+      // redirect somewhere or something. up to you. the email was sent successfully.
+    } else {
+      alert(response.error.message);
+    }
+  });
+
+  return false;
+});
+```
+
+If your site has a "Contact Us" form to enable a customer to send you messages, you will want to use a similar set up to the above example. The only difference is that instead of sending an email to the user, you want it sent to you and have it sent from the user.
+
+```javascript
+$("form#id").submit(function() {
+  var sendgridjs_url      = "http://yoursubdomain.herokuapp.com/send";
+  var sendgridjs_from     = $("input#from").val();
+  var sendgridjs_subject  = $("input#subject").val();
+  var sendgridjs_html     = "<p>html of email here as a string</p>";
+
+  var email = {
+    from    : sendgridjs_from,
     subject : sendgridjs_subject,
     html    : sendgridjs_html
   }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Proxy so you can send email via JavaScript through SendGrid.
 
-## Usage 
+## Usage
 
 First, deploy to Heroku by clicking this button.
 
@@ -21,19 +21,19 @@ curl -X POST http://yoursubdomain.herokuapp.com/send \
 
 #### Optional: Using with JavaScript and HTML.
 
-You might have a website with a form and you want to send emails from that form. After setting up this app, you can send emails by adding the following javascript to your html page.
+You might have a website with a form and you want to send emails from that form to yourself. After setting up this app, you can send emails by adding the following javascript to your html page.
 
 First, make sure you add jQuery to your page. Then do the following on form submit.
 
 ```javascript
 $("form#id").submit(function() {
   var sendgridjs_url      = "http://yoursubdomain.herokuapp.com/send";
-  var sendgridjs_to       = $("input#to").val();
+  var sendgridjs_from       = $("input#from").val();
   var sendgridjs_subject  = $("input#subject").val();
   var sendgridjs_html     = "<p>html of email here as a string</p>";
 
   var email = {
-    to      : sendgridjs_to, 
+    from    : sendgridjs_to,
     subject : sendgridjs_subject,
     html    : sendgridjs_html
   }
@@ -69,5 +69,3 @@ a matter of seconds:
 
 [![Hack scottmotte/sendgridjs on
 Nitrous.IO](https://d3o0mnbgv6k92a.cloudfront.net/assets/hack-l-v1-3cc067e71372f6045e1949af9d96095b.png)](https://www.nitrous.io/hack_button?source=embed&runtime=nodejs&repo=scottmotte%2Fsendgridjs&file_to_open=README.nitrous.md)
-
-

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -6,7 +6,7 @@ Run the following commands in the terminal below:
 2. Run `cp .env-example .env`
 3. In the `.env` file, replace `SENDGRID_USERNAME` to your Sendgrid Username
 4. In the `.env` file, replace `SENDGRID_PASSWORD` to your Sendgrid Password
-5. In the `.env` file, replace `TO` to your email address
+5. In the `.env` file, either replace `FROM` or `TO` to your email address. Delete the one that you want a user to be able to customize.
 6. Run `npm install`
 6. Run `node app.js`
 

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -6,7 +6,7 @@ Run the following commands in the terminal below:
 2. Run `cp .env-example .env`
 3. In the `.env` file, replace `SENDGRID_USERNAME` to your Sendgrid Username
 4. In the `.env` file, replace `SENDGRID_PASSWORD` to your Sendgrid Password
-5. In the `.env` file, replace `FROM` to your email address
+5. In the `.env` file, replace `TO` to your email address
 6. Run `npm install`
 6. Run `node app.js`
 

--- a/README.nitrous.md
+++ b/README.nitrous.md
@@ -6,7 +6,7 @@ Run the following commands in the terminal below:
 2. Run `cp .env-example .env`
 3. In the `.env` file, replace `SENDGRID_USERNAME` to your Sendgrid Username
 4. In the `.env` file, replace `SENDGRID_PASSWORD` to your Sendgrid Password
-5. In the `.env` file, either replace `FROM` or `TO` to your email address. Delete the one that you want a user to be able to customize.
+5. In the `.env` file, either replace `FROM` or `TO` with your email address. Delete the one that you want a user to be able to customize.
 6. Run `npm install`
 6. Run `node app.js`
 

--- a/app.js
+++ b/app.js
@@ -3,7 +3,7 @@ dotenv.load();
 
 var e           = module.exports;
 e.ENV           = process.env.NODE_ENV || 'development';
-FROM            = process.env.FROM
+TO            = process.env.TO
 
 sendgrid_username   = process.env.SENDGRID_USERNAME;
 var sendgrid_password   = process.env.SENDGRID_PASSWORD;
@@ -16,5 +16,3 @@ var Hapi        = require('hapi');
 server          = new Hapi.Server(+port, '0.0.0.0', { cors: true });
 require('./routes');
 server.start();
-
-

--- a/app.js
+++ b/app.js
@@ -3,7 +3,8 @@ dotenv.load();
 
 var e           = module.exports;
 e.ENV           = process.env.NODE_ENV || 'development';
-TO            = process.env.TO
+FROM            = process.env.FROM;
+TO              = process.env.TO;
 
 sendgrid_username   = process.env.SENDGRID_USERNAME;
 var sendgrid_password   = process.env.SENDGRID_PASSWORD;

--- a/app.json
+++ b/app.json
@@ -11,8 +11,12 @@
   "repository": "https://github.com/sendgrid/sendgridjs",
   "logo": "https://raw.githubusercontent.com/sendgrid/sendgridjs/master/sendgridjs.jpg",
   "env": {
+    "FROM": {
+      "description": "This should be the 'from' email address your users see when receiving email from your application. **YOU** are sending this email.",
+      "value": "you@youremail.com"
+    },
     "TO": {
-      "description": "This should be the 'to' email address your users are sending messages to via your application.  YOU are receiving this email.",
+      "description": "This should be the 'to' email address your users are sending messages to via your application's Contact Form.  **YOU** are receiving this email.",
       "value": "you@youremail.com"
     }
   },

--- a/app.json
+++ b/app.json
@@ -11,8 +11,8 @@
   "repository": "https://github.com/sendgrid/sendgridjs",
   "logo": "https://raw.githubusercontent.com/sendgrid/sendgridjs/master/sendgridjs.jpg",
   "env": {
-    "FROM": {
-      "description": "This should be the 'from' email address your users see when receiving email from your application.",
+    "TO": {
+      "description": "This should be the 'to' email address your users are sending messages to via your application.  YOU are receiving this email.",
       "value": "you@youremail.com"
     }
   },

--- a/routes/send.js
+++ b/routes/send.js
@@ -2,14 +2,14 @@ var send = {
   index: {
     handler: function (request) {
       var payload   = request.payload;
-      var to        = payload.to;
+      var from      = payload.from;
       var subject   = payload.subject;
       var html      = payload.html;
       var email     = {
-        to:       to,
-        from:     FROM,
+        to:       TO,
+        from:     from,
         subject:  subject,
-        html:     html 
+        html:     html
       }
 
       SendGrid.send(email, function(success, message) {

--- a/routes/send.js
+++ b/routes/send.js
@@ -2,11 +2,12 @@ var send = {
   index: {
     handler: function (request) {
       var payload   = request.payload;
-      var from      = payload.from;
+      var from      = FROM || payload.from;
+      var to        = TO || payload.to;
       var subject   = payload.subject;
       var html      = payload.html;
       var email     = {
-        to:       TO,
+        to:       to,
         from:     from,
         subject:  subject,
         html:     html


### PR DESCRIPTION
Added option to allow developer to hard-code a recipient's email address.  This functionality is used for a website's "Contact Us" form, where a new user would write his/her email address and a message.  This message would be sent to the website's email address.